### PR TITLE
🐛 [-bug] Fixed issue with empty StreamDecorators and capabilities

### DIFF
--- a/src/dbrownell_Common/Streams/StreamDecorator.py
+++ b/src/dbrownell_Common/Streams/StreamDecorator.py
@@ -117,7 +117,7 @@ class StreamDecorator(TextWriter):
             capabilities = lowest_capabilities
 
         else:
-            capabilities = Capabilities()
+            capabilities = Capabilities(ignore_environment=True)
 
         Capabilities.Set(self, capabilities)
 


### PR DESCRIPTION
Default Capabilities are created for empty StreamDecorators (e.g. `StreamDecorator(None)`). However, the default Capabilities constructor looks at environment variables to override values when none are provided. In this case, we don't want to look at those values and use the lowest settings available.

The fix is to ignore the environment when creating the Capabilities to associate with the empty StreamDecorator.