### PR TITLE
✨ [+feature] num_cols in DoneManager can set sys.stdout Capabilities

### DIFF
--- a/src/dbrownell_Common/Streams/DoneManager.py
+++ b/src/dbrownell_Common/Streams/DoneManager.py
@@ -191,6 +191,11 @@ class Flags(Flag):
 
 
 # ----------------------------------------------------------------------
+# Set the number of columns to the terminal width
+SCREEN_WIDTH = -1
+
+
+# ----------------------------------------------------------------------
 @dataclass(frozen=True)
 class Args:
     """Arguments provided when creating DoneManager instances"""
@@ -327,9 +332,29 @@ class DoneManager:
         *,
         flags: Flags = Flags.Standard,
         display: bool = True,
+        no_column_warning: bool = False,
         **kwargs,
     ) -> Iterator["DoneManager"]:
         """Creates a DoneManager instance suitable for use with command-line functionality."""
+
+        # Set the number of columns to display on the terminal
+        if not Capabilities.IsSet(stream):
+            num_cols: Optional[int] = kwargs.get("num_cols", None)
+
+            if num_cols == SCREEN_WIDTH:
+                num_cols = os.get_terminal_size().columns
+                kwargs["num_cols"] = num_cols
+
+            capabilities = Capabilities.Get(stream)
+
+            if num_cols is not None:
+                capabilities = capabilities.Clone(columns=num_cols)
+
+            Capabilities.Set(
+                stream,
+                capabilities,
+                no_column_warning=no_column_warning,
+            )
 
         if display:
             prefix = "\nResults: "

--- a/src/dbrownell_Common/TestHelpers/StreamTestHelpers.py
+++ b/src/dbrownell_Common/TestHelpers/StreamTestHelpers.py
@@ -157,11 +157,14 @@ def InitializeStreamCapabilities(
     os.environ[Capabilities.SIMULATE_TERMINAL_HEADLESS_ENV_VAR] = "1"
 
     # Associate the capabilities with the stream
-    Capabilities(
-        columns=Capabilities.DEFAULT_COLUMNS,
-        is_interactive=False,
-        is_headless=True,
-        supports_colors=True,
-        stream=stream,
+    Capabilities.Set(
+        stream,
+        Capabilities(
+            columns=Capabilities.DEFAULT_COLUMNS,
+            is_interactive=False,
+            is_headless=True,
+            supports_colors=True,
+            stream=stream,
+        ),
         no_column_warning=True,
     )

--- a/tests/Streams/Capabilities_UnitTest.py
+++ b/tests/Streams/Capabilities_UnitTest.py
@@ -16,6 +16,7 @@
 import re
 import sys
 
+from io import StringIO
 from unittest.mock import MagicMock as Mock
 
 import pytest
@@ -77,8 +78,11 @@ def test_WithStdout():
         columns=columns,
     )
 
-    assert Capabilities._processed_stdout is True
+    assert Capabilities._processed_stdout is False
     assert c.columns == columns
+
+    Capabilities.Set(sys.stdout, c)
+    assert Capabilities._processed_stdout is True
 
 
 # ----------------------------------------------------------------------
@@ -89,10 +93,21 @@ def test_SetError():
     with pytest.raises(
         Exception,
         match=re.escape(
-            "Capabilities are assigned to a stream when it is first created and cannot be changed; consider using the `Clone` method."
+            "Capabilities have already been applied to this stream; consider using the `Clone` method."
         ),
     ):
-        Capabilities(stream=stream)
+        Capabilities.Set(stream, Capabilities(stream=stream))
+
+
+# ----------------------------------------------------------------------
+def test_IsSet():
+    stream = StringIO()
+
+    assert not Capabilities.IsSet(stream)
+
+    Capabilities.Set(stream, Capabilities(stream=stream))
+
+    assert Capabilities.IsSet(stream)
 
 
 # ----------------------------------------------------------------------

--- a/tests/Streams/DoneManager_UnitTest.py
+++ b/tests/Streams/DoneManager_UnitTest.py
@@ -444,6 +444,8 @@ def test_Capabilities():
     sink = StringIO()
     capabilities = Capabilities(stream=sink)
 
+    Capabilities.Set(sink, capabilities)
+
     with DoneManager.Create(sink, "Testing") as dm:
         assert dm.capabilities is capabilities
 
@@ -1524,11 +1526,14 @@ class _FakeStream(TextWriter):
         self._fileno = fileno
         self._isatty = isatty
 
-        Capabilities(
-            stream=self,
-            is_headless=is_headless,
-            is_interactive=is_interactive,
-            supports_colors=supports_colors,
+        Capabilities.Set(
+            self,
+            Capabilities(
+                stream=self,
+                is_headless=is_headless,
+                is_interactive=is_interactive,
+                supports_colors=supports_colors,
+            ),
         )
 
     # ----------------------------------------------------------------------
@@ -1566,11 +1571,14 @@ def _CreateSink(
 ) -> StringIO:
     sink = StringIO()
 
-    Capabilities(
-        stream=sink,
-        is_headless=True,
-        is_interactive=False,
-        supports_colors=supports_colors,
+    Capabilities.Set(
+        sink,
+        Capabilities(
+            stream=sink,
+            is_headless=True,
+            is_interactive=False,
+            supports_colors=supports_colors,
+        ),
     )
 
     return sink


### PR DESCRIPTION
## :pencil: Description
num_cols in DoneManager can optionally set sys.stdout Capabilities.

## :gear: Work Item
https://github.com/davidbrownell/dbrownell_Common/issues/64

## :movie_camera: Demo
```
# Default (180 cols)
with DoneManager.CreateCommandLine(
    flags=DoneManagerFlags.Create(verbose=verbose, debug=debug)
) as dm:
```
<img width="2433" height="223" alt="image" src="https://github.com/user-attachments/assets/5e306e2e-7f40-4556-ab05-e4291b85ca26" />

```
# Explicitly set to 30 cols
with DoneManager.CreateCommandLine(
    flags=DoneManagerFlags.Create(verbose=verbose, debug=debug),
    num_cols=30,
) as dm:
```
<img width="2429" height="650" alt="image" src="https://github.com/user-attachments/assets/d74dcbe1-80ad-4938-963b-d601cda41e2e" />

```
# Explicitly set to 30 cols, no column warning
with DoneManager.CreateCommandLine(
    flags=DoneManagerFlags.Create(verbose=verbose, debug=debug),
    num_cols=30,
    no_column_warning=True,
) as dm:
```
<img width="2427" height="540" alt="image" src="https://github.com/user-attachments/assets/2b460646-869b-47e7-82aa-1792e3ab2537" />

```
# Set to the current terminal width (wide screen)
with DoneManager.CreateCommandLine(
    flags=DoneManagerFlags.Create(verbose=verbose, debug=debug),
    num_cols=SCREEN_WIDTH,
) as dm:
```
<img width="2449" height="185" alt="image" src="https://github.com/user-attachments/assets/927f3a96-4142-484d-997a-3dbf366310aa" />

```
# Set to the current terminal width (narrow screen)
with DoneManager.CreateCommandLine(
    flags=DoneManagerFlags.Create(verbose=verbose, debug=debug),
    num_cols=SCREEN_WIDTH,
) as dm:
```
<img width="838" height="367" alt="image" src="https://github.com/user-attachments/assets/e2c46e61-0208-4b34-972e-2e991075c1bb" />
